### PR TITLE
Add cy.intercept() snippet

### DIFF
--- a/packages/cypress-snippets/snippets/snippets.json
+++ b/packages/cypress-snippets/snippets/snippets.json
@@ -59,15 +59,20 @@
     "body": ["\nclick()${0:;}"],
     "description": "Cypress click"
   },
+    "intercept": {
+    "prefix": "cyi",
+    "body": ["cy.intercept(${2:'$3', }$1).as('${4}');$0"],
+    "description": "Cypress intercept"
+  },
   "server": {
     "prefix": "cyserver",
     "body": ["cy.server();$0"],
-    "description": "Cypress server"
+    "description": "Cypress server (deprecated)"
   },
   "route": {
     "prefix": "cyroute",
     "body": ["cy.route(${2:'$3', }$1).as('${4}');$0"],
-    "description": "Cypress route"
+    "description": "Cypress route (deprecated)"
   },
   "wait": {
     "prefix": "cyw",


### PR DESCRIPTION
Also added '(deprecated)' to the server and route descriptions. I considered removing these snippets entirely, but they're still valid commands in the current version of Cypress so I thought it best to leave them in place for now.